### PR TITLE
Improvements and fixes to index.test.js

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -63,7 +63,6 @@ describe('Phishing warning page', () => {
   });
 
   afterEach(() => {
-    onDomContentLoad = undefined;
     document.getElementsByTagName('html')[0].innerHTML = '';
   });
 
@@ -109,7 +108,7 @@ describe('Phishing warning page', () => {
     await import('./index');
     // non-null assertion used because TypeScript doesn't know the event handler was run
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    expect(() => onDomContentLoad!(new Event('DOMContentLoaded'))).toThrow('');
+    expect(() => onDomContentLoad!(new Event('DOMContentLoaded'))).toThrow("Missing 'hostname' query parameter");
   });
 
   it('should throw an error if the href is missing', async () => {
@@ -118,7 +117,7 @@ describe('Phishing warning page', () => {
     await import('./index');
     // non-null assertion used because TypeScript doesn't know the event handler was run
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    expect(() => onDomContentLoad!(new Event('DOMContentLoaded'))).toThrow('');
+    expect(() => onDomContentLoad!(new Event('DOMContentLoaded'))).toThrow("Missing 'href' query parameter");
   });
 
   it('should throw an error if the new issue link is missing', async () => {
@@ -132,7 +131,7 @@ describe('Phishing warning page', () => {
     await import('./index');
     // non-null assertion used because TypeScript doesn't know the event handler was run
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    expect(() => onDomContentLoad!(new Event('DOMContentLoaded'))).toThrow('');
+    expect(() => onDomContentLoad!(new Event('DOMContentLoaded'))).toThrow('Unable to locate new issue link');
   });
 
   it('should throw an error if the continue link is missing', async () => {
@@ -146,6 +145,6 @@ describe('Phishing warning page', () => {
     await import('./index');
     // non-null assertion used because TypeScript doesn't know the event handler was run
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    expect(() => onDomContentLoad!(new Event('DOMContentLoaded'))).toThrow('');
+    expect(() => onDomContentLoad!(new Event('DOMContentLoaded'))).toThrow('Unable to locate unsafe continue link');
   });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -46,8 +46,8 @@ function mockLocation(url: string) {
 
 describe('Phishing warning page', () => {
   let onDomContentLoad: EventListener | undefined;
-  beforeEach(() => {
-    document.getElementsByTagName('html')[0].innerHTML = phishingHtml;
+
+  beforeAll(async () => {
     jest
       .spyOn(window.document, 'addEventListener')
       .mockImplementation(
@@ -60,6 +60,11 @@ describe('Phishing warning page', () => {
           }
         },
       );
+    await import('./index');
+  });
+
+  beforeEach(() => {
+    document.getElementsByTagName('html')[0].innerHTML = phishingHtml;
   });
 
   afterEach(() => {
@@ -83,7 +88,6 @@ describe('Phishing warning page', () => {
   it('should correctly construct "New issue" link', async () => {
     mockLocation(getUrl('example.com', 'https://example.com'));
 
-    await import('./index');
     // non-null assertion used because TypeScript doesn't know the event handler was run
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     onDomContentLoad!(new Event('DOMContentLoaded'));
@@ -105,19 +109,21 @@ describe('Phishing warning page', () => {
   it('should throw an error if the hostname is missing', async () => {
     mockLocation(getUrl(undefined, 'https://example.com'));
 
-    await import('./index');
     // non-null assertion used because TypeScript doesn't know the event handler was run
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    expect(() => onDomContentLoad!(new Event('DOMContentLoaded'))).toThrow("Missing 'hostname' query parameter");
+    expect(() => onDomContentLoad!(new Event('DOMContentLoaded'))).toThrow(
+      "Missing 'hostname' query parameter",
+    );
   });
 
   it('should throw an error if the href is missing', async () => {
     mockLocation(getUrl('example.com'));
 
-    await import('./index');
     // non-null assertion used because TypeScript doesn't know the event handler was run
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    expect(() => onDomContentLoad!(new Event('DOMContentLoaded'))).toThrow("Missing 'href' query parameter");
+    expect(() => onDomContentLoad!(new Event('DOMContentLoaded'))).toThrow(
+      "Missing 'href' query parameter",
+    );
   });
 
   it('should throw an error if the new issue link is missing', async () => {
@@ -128,10 +134,11 @@ describe('Phishing warning page', () => {
     }
     newIssueLink.remove();
 
-    await import('./index');
     // non-null assertion used because TypeScript doesn't know the event handler was run
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    expect(() => onDomContentLoad!(new Event('DOMContentLoaded'))).toThrow('Unable to locate new issue link');
+    expect(() => onDomContentLoad!(new Event('DOMContentLoaded'))).toThrow(
+      'Unable to locate new issue link',
+    );
   });
 
   it('should throw an error if the continue link is missing', async () => {
@@ -142,9 +149,10 @@ describe('Phishing warning page', () => {
     }
     continueLink.remove();
 
-    await import('./index');
     // non-null assertion used because TypeScript doesn't know the event handler was run
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    expect(() => onDomContentLoad!(new Event('DOMContentLoaded'))).toThrow('Unable to locate unsafe continue link');
+    expect(() => onDomContentLoad!(new Event('DOMContentLoaded'))).toThrow(
+      'Unable to locate unsafe continue link',
+    );
   });
 });


### PR DESCRIPTION
This PR makes two changes:

First, because of `onDomContentLoad = undefined;` in `afterEach`, the error being thrown in each of the tests intended to test errors is `"onDomContentLoad is not a function"` and not the error that is being expected. These tests were passing because the `toThrow` assertion checks that the "error message _includes_ the substring" if its param is a string (https://jestjs.io/docs/expect#tothrowerror). By removing `onDomContentLoad = undefined;`, we can successfully assert the exact error messages we expect.

Now, you might ask why do we need to remove `onDomContentLoad = undefined;`, doesn't the jest spy on `window.document.addEventListener` ensure it gets set with each call to `await import('./index');`. It turns out that only the first call to `await import('./index');` was running the index.js script, likely due to caching by node.js. Therefore, `window.document.addEventListener('DOMContentLoaded'` is only getting called once, despite the  `await import('./index');` calls in multiple tests.

This is the motivation of the second change in this PR. `await import('./index');` has been removed from individual tests and moved to a `beforeAll` call. This is because only the first such call has any effect.  