### PR TITLE
Allow newIssueUrl to be specified by a hash query param

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -18,9 +18,13 @@ const phishingHtml = readFileSync(
  * @param href - The href to include in the URL fragment.
  * @returns The phishing warning page URL.
  */
-function getUrl(hostname?: string, href?: string) {
+function getUrl(hostname?: string, href?: string, newIssueUrl?: string) {
   const baseUrl = 'https://metamask.github.io/phishing-warning/#';
-  if (hostname && href) {
+  if (hostname && href && newIssueUrl) {
+    return `${baseUrl}hostname=${encodeURIComponent(
+      hostname,
+    )}&href=${encodeURIComponent(href)}&newIssueUrl=${encodeURIComponent(newIssueUrl)}`;
+  } else if (hostname && href) {
     return `${baseUrl}hostname=${encodeURIComponent(
       hostname,
     )}&href=${encodeURIComponent(href)}`;
@@ -95,6 +99,32 @@ describe('Phishing warning page', () => {
     const newIssueLink = window.document.getElementById('new-issue-link');
     expect(newIssueLink?.getAttribute('href')).toBe(
       'https://github.com/MetaMask/eth-phishing-detect/issues/new?title=[Legitimate%20Site%20Blocked]%20example.com&body=https%3A%2F%2Fexample.com',
+    );
+  });
+
+  it('should correctly construct "New issue" link', async () => {
+    mockLocation(getUrl('example.com', 'https://example.com'));
+
+    // non-null assertion used because TypeScript doesn't know the event handler was run
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    onDomContentLoad!(new Event('DOMContentLoaded'));
+
+    const newIssueLink = window.document.getElementById('new-issue-link');
+    expect(newIssueLink?.getAttribute('href')).toBe(
+      'https://github.com/MetaMask/eth-phishing-detect/issues/new?title=[Legitimate%20Site%20Blocked]%20example.com&body=https%3A%2F%2Fexample.com',
+    );
+  });
+
+  it('should have the correct "New issue" link if a newIssueUrl is specified in the hash query string', async () => {
+    mockLocation(getUrl('example.com', 'https://example.com', 'https://example.com'));
+
+    // non-null assertion used because TypeScript doesn't know the event handler was run
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    onDomContentLoad!(new Event('DOMContentLoaded'));
+
+    const newIssueLink = window.document.getElementById('new-issue-link');
+    expect(newIssueLink?.getAttribute('href')).toBe(
+      'https://example.com?title=[Legitimate%20Site%20Blocked]%20example.com&body=https%3A%2F%2Fexample.com',
     );
   });
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -16,6 +16,8 @@ const phishingHtml = readFileSync(
  *
  * @param hostname - The hostname to include in the URL fragment.
  * @param href - The href to include in the URL fragment.
+ * @param newIssueUrl - Optional, the url for the new issue link
+ * to include in in the URL fragment.
  * @returns The phishing warning page URL.
  */
 function getUrl(hostname?: string, href?: string, newIssueUrl?: string) {
@@ -23,7 +25,9 @@ function getUrl(hostname?: string, href?: string, newIssueUrl?: string) {
   if (hostname && href && newIssueUrl) {
     return `${baseUrl}hostname=${encodeURIComponent(
       hostname,
-    )}&href=${encodeURIComponent(href)}&newIssueUrl=${encodeURIComponent(newIssueUrl)}`;
+    )}&href=${encodeURIComponent(href)}&newIssueUrl=${encodeURIComponent(
+      newIssueUrl,
+    )}`;
   } else if (hostname && href) {
     return `${baseUrl}hostname=${encodeURIComponent(
       hostname,
@@ -102,21 +106,10 @@ describe('Phishing warning page', () => {
     );
   });
 
-  it('should correctly construct "New issue" link', async () => {
-    mockLocation(getUrl('example.com', 'https://example.com'));
-
-    // non-null assertion used because TypeScript doesn't know the event handler was run
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    onDomContentLoad!(new Event('DOMContentLoaded'));
-
-    const newIssueLink = window.document.getElementById('new-issue-link');
-    expect(newIssueLink?.getAttribute('href')).toBe(
-      'https://github.com/MetaMask/eth-phishing-detect/issues/new?title=[Legitimate%20Site%20Blocked]%20example.com&body=https%3A%2F%2Fexample.com',
-    );
-  });
-
   it('should have the correct "New issue" link if a newIssueUrl is specified in the hash query string', async () => {
-    mockLocation(getUrl('example.com', 'https://example.com', 'https://example.com'));
+    mockLocation(
+      getUrl('example.com', 'https://example.com', 'https://example.com'),
+    );
 
     // non-null assertion used because TypeScript doesn't know the event handler was run
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,7 +109,7 @@ function start() {
     throw new Error('Unable to locate new issue link');
   }
 
-  const newIssueUrl = `https://github.com/MetaMask/eth-phishing-detect/issues/new`;
+  const newIssueUrl = hashQueryString.get('newIssueUrl') || `https://github.com/MetaMask/eth-phishing-detect/issues/new`;
   const newIssueParams = `?title=[Legitimate%20Site%20Blocked]%20${encodeURIComponent(
     suspectHostname,
   )}&body=${encodeURIComponent(suspectHref)}`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,7 +109,9 @@ function start() {
     throw new Error('Unable to locate new issue link');
   }
 
-  const newIssueUrl = hashQueryString.get('newIssueUrl') || `https://github.com/MetaMask/eth-phishing-detect/issues/new`;
+  const newIssueUrl =
+    hashQueryString.get('newIssueUrl') ||
+    `https://github.com/MetaMask/eth-phishing-detect/issues/new`;
   const newIssueParams = `?title=[Legitimate%20Site%20Blocked]%20${encodeURIComponent(
     suspectHostname,
   )}&body=${encodeURIComponent(suspectHref)}`;


### PR DESCRIPTION
Fixes https://github.com/MetaMask/phishing-warning/issues/15

Blocked by https://github.com/MetaMask/phishing-warning/pull/22, currently comparing to that branch but should be rebased onto main after #22 is merged. Leaving in draft until then.

This PR adds handling for a `newIssueUrl` query parameter, allowing anyone directing a user to the phishing-warning page to specify which url they should go to when clicking "please file an issue"

To resolve the breaking change in metamask-extension that comes with the version bump to v30.0.0,  https://github.com/MetaMask/metamask-extension/pull/15160 is needed in addition to this PR