### PR TITLE
Fix `gh-pages` publishing

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -26,4 +26,4 @@ jobs:
           node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
       - uses: MetaMask/action-publish-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.METAMASKBOT_PUBLISH_TOKEN }}


### PR DESCRIPTION
The `gh-pages` actions were not triggering because they are triggered by a tag. The tag was being added by GitHub actions, so the trigger failed because GitHub actions ignores self-initiated events.

A personal access token belonging to the `metamaskbot` account has been added to this repository as a secret. This allows us to tag using the bot's account, ensuring the later triggers work correctly.

Fixes #13