### PR TITLE
Fix build script

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import pump from 'pump';
-import { WindowPostMessageStream } from '@metamask/post-message-stream';
+import { WindowPostMessageStream } from '@metamask/post-message-stream/dist/window/WindowPostMessageStream';
 import ObjectMultiplex from 'obj-multiplex';
 
 const MAX = Number.MAX_SAFE_INTEGER;


### PR DESCRIPTION
The build script has been failing since `@metamask/post-message-stream` was updated. This appears to be caused by the addition of modules to that library that were meant to be used in the context of a Web Worker. They referenced an import that only exists in a Web Worker context (`worker_threads`). They were included in the main entrypoint for the package, so browserify tried to walk the dependency graph and blew up on that line.

The import has been updated to reference just the `WindowPostMessageStream` module that is used, rather than the main package entrypoint.