### PR TITLE
Ensure build script has failing exit code upon failure

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -95,4 +95,7 @@ async function main() {
   await generateServiceWorker();
 }
 
-main().catch(console.error);
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
The build script was exiting with an exit code of zero even when it had failed. The build script has been updated to ensure it always returns an exit code of 1 upon failure, which in turn should ensure CI fails.