### PR TITLE
Revert build script change that is no longer needed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import pump from 'pump';
-import { WindowPostMessageStream } from '@metamask/post-message-stream/dist/window/WindowPostMessageStream';
+import { WindowPostMessageStream } from '@metamask/post-message-stream';
 import ObjectMultiplex from 'obj-multiplex';
 
 const MAX = Number.MAX_SAFE_INTEGER;


### PR DESCRIPTION
This reverts commit e9eddaffbadeb8b9cec06ff523b31d44bd2c244c. This change was made to resolve a breakage introduced in `@metamask.post-message-stream`. This breakage was fixed in v6 of that library, so we don't need to use a direct import anymore.

For further details, see: https://github.com/MetaMask/post-message-stream/pull/49