### PR TITLE
Allowlist protocols valid for new issue url

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -25,7 +25,7 @@ const config: Config.InitialOptions = {
   collectCoverage: true,
 
   // An array of glob patterns indicating a set of files for which coverage information should be collected
-  collectCoverageFrom: ['./src/**/*.ts'],
+  collectCoverageFrom: ['./src/**/*.ts', '!./src/**/types.ts'],
 
   // The directory where Jest should output its coverage files
   coverageDirectory: 'coverage',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,4 @@
+export const PHISHING_DETECT_NEW_ISSUE_URL =
+  'https://github.com/MetaMask/eth-phishing-detect/issues/new';
+
+export const ACCEPTED_PROTOCOLS_DISPUTE_URL = ['https:'];

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -116,6 +116,44 @@ describe('Phishing warning page', () => {
     );
   });
 
+  it('should not show where to report an issue if the issue URL uses an invalid protocol', async () => {
+    // eslint-disable-next-line no-script-url
+    const invalidIssueUrl = 'javascript:alert(1)';
+
+    window.document.location.href = getUrl(
+      'hostname.com',
+      'https://href.com',
+      invalidIssueUrl,
+    );
+    // non-null assertion used because TypeScript doesn't know the event handler was run
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    onDomContentLoad!(new Event('DOMContentLoaded'));
+
+    const newIssueLink = window.document.getElementById(
+      'open-new-issue-content',
+    );
+    expect(newIssueLink).toBeNull();
+  });
+
+  it('should show where to report an issue if the issue URL uses a valid protocol', async () => {
+    const validIssueUrl = 'https://example.com';
+
+    window.document.location.href = getUrl(
+      'hostname.com',
+      'https://href.com',
+      validIssueUrl,
+    );
+
+    // non-null assertion used because TypeScript doesn't know the event handler was run
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    onDomContentLoad!(new Event('DOMContentLoaded'));
+
+    const newIssueLink = window.document.getElementById(
+      'open-new-issue-content',
+    );
+    expect(newIssueLink).not.toBeNull();
+  });
+
   it.todo(
     'should add site to safelist when the user continues at their own risk',
   );
@@ -179,6 +217,24 @@ describe('Phishing warning page', () => {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(() => onDomContentLoad!(new Event('DOMContentLoaded'))).toThrow(
       'Unable to locate new issue link',
+    );
+  });
+
+  it('should throw an error if the open-new-issue-content is missing', async () => {
+    window.document.location.href = getUrl(
+      'example.com',
+      'https://example.com',
+    );
+    const openIssueContent = document.getElementById('open-new-issue-content');
+    if (!openIssueContent) {
+      throw new Error('Unable to locate open-new-issue-content');
+    }
+    openIssueContent.remove();
+
+    // non-null assertion used because TypeScript doesn't know the event handler was run
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect(() => onDomContentLoad!(new Event('DOMContentLoaded'))).toThrow(
+      'Unable to locate content to prompt opening a dispute issue.',
     );
   });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,5 @@
+export interface PageParameters {
+  href: string;
+  hostname: string;
+  newIssueUrl?: string;
+}

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -1,0 +1,1 @@
+export * from './utilities';

--- a/src/utilities/utilities.test.ts
+++ b/src/utilities/utilities.test.ts
@@ -1,0 +1,69 @@
+import { usesAcceptedProtocol, buildNewIssueURL } from './utilities';
+
+describe('usesAcceptedProtocol', () => {
+  it('should return true for https urls', () => {
+    expect(usesAcceptedProtocol('https://example.com')).toBe(true);
+  });
+
+  it('should return false for http urls', () => {
+    expect(usesAcceptedProtocol('http://example.com')).toBe(false);
+  });
+
+  it('should return false for invalid urls', () => {
+    expect(usesAcceptedProtocol('12345')).toBe(false);
+  });
+
+  it('should return false for urls with any other protocol', () => {
+    expect(usesAcceptedProtocol('foo:bar.com')).toBe(false);
+  });
+});
+
+describe('buildNewIssueURL', () => {
+  const defaultParams = {
+    hostname: 'example.com',
+    href: 'https://example.com/',
+    newIssueUrl: 'some-url.com',
+  };
+
+  it('url encodes hostname in new issue params', () => {
+    const hostname = 'foobar.net/../../';
+    const encodedHostname = 'foobar.net%2F..%2F..%2F';
+
+    const url = buildNewIssueURL({
+      ...defaultParams,
+      hostname,
+    });
+
+    expect(url).toContain(encodedHostname);
+    expect(url).not.toContain(hostname);
+  });
+
+  it('url encodes href', () => {
+    const href = 'https://example.com/../../';
+    const encodedHref = 'https%3A%2F%2Fexample.com%2F..%2F..%2F';
+
+    const url = buildNewIssueURL({
+      ...defaultParams,
+      href,
+    });
+
+    expect(url).toContain(encodedHref);
+    expect(url).not.toContain(href);
+  });
+
+  it('uses newIssueUrl to determine where to link to', () => {
+    const url = buildNewIssueURL({
+      ...defaultParams,
+      newIssueUrl: 'https://foobar.com',
+    });
+
+    expect(url.startsWith('https://foobar.com')).toBe(true);
+
+    const anotherUrl = buildNewIssueURL({
+      ...defaultParams,
+      newIssueUrl: 'https://anotherfoobar.com',
+    });
+
+    expect(anotherUrl.startsWith('https://anotherfoobar.com')).toBe(true);
+  });
+});

--- a/src/utilities/utilities.ts
+++ b/src/utilities/utilities.ts
@@ -1,0 +1,37 @@
+import { PageParameters } from '../types';
+import { ACCEPTED_PROTOCOLS_DISPUTE_URL } from '../constants';
+
+/**
+ * Returns boolean true if the URL uses the HTTPS protocol false otherwise.
+ *
+ * @param url - The URL to check.
+ * @returns Boolean indicating if HTTPS is used.
+ */
+export function usesAcceptedProtocol(url: string) {
+  try {
+    const parsedUrl = new URL(url);
+    return ACCEPTED_PROTOCOLS_DISPUTE_URL.includes(parsedUrl.protocol);
+  } catch (e) {
+    return false;
+  }
+}
+
+/**
+ * Builds a URL string that is used as the location to dispute a phishing warning.
+ *
+ * @param PageParameters - The parameters to use when building the URL.
+ * @param PageParameters.hostname - The hostname of the phishing site.
+ * @param PageParameters.href - The complete url the user was blocked from visiting.
+ * @param PageParameters.newIssueUrl - The page where the user can dispute a phishing warning.
+ * @returns String of url.
+ */
+export function buildNewIssueURL({
+  hostname,
+  href,
+  newIssueUrl,
+}: PageParameters) {
+  const encodedHostname = encodeURIComponent(hostname);
+  const encodedHref = encodeURIComponent(href);
+
+  return `${newIssueUrl}?title=[Legitimate%20Site%20Blocked]%20${encodedHostname}&body=${encodedHref}`;
+}

--- a/static/index.html
+++ b/static/index.html
@@ -86,7 +86,7 @@
           you wish to interact with any domain on our warning list, you can do
           so by <a id="unsafe-continue">continuing at your own risk</a>.</span>
         </p>
-        <p>
+        <p id="open-new-issue-content">
           If you think this domain is incorrectly flagged or if a blocked
           legitimate website has resolved its security issues,
           <a


### PR DESCRIPTION
## Summary
When visiting the phishing page the following content is displayed at the bottom:

<img width="976" alt="Screen Shot 2022-09-21 at 12 16 27 PM" src="https://user-images.githubusercontent.com/15018469/191557220-7d12cc57-932f-4b74-b11f-f3fb6ad22cc5.png">

This allows for the user to visit MetaMask's [eth-phishing-detect](https://github.com/MetaMask/eth-phishing-detect) repository where they can then appeal to have their website removed from our phishing list. However, there are cases where external lists may be used to determine which pages to block. In these cases, we allow for a custom `newIssueUrl` parameter to be passed to the webpage, and have the user be redirected to the owners of these external phishing lists to make an appeal.

## Problem

We do not perform validation on the `newIssueUrl`'s that are provided which can lead to invalid or malicious URLs being linked to by the `please file an issue` link on this page. 

## Solution

This pull request introduces changes to ensure that only URL's with the HTTPS protocol are allowed to be used as custom URLs to open new issues.  When an invalid URL is given, I hide the option to open an issue. 

## Demo

**Before**
https://user-images.githubusercontent.com/15018469/191559125-a9acea76-b28b-4ce0-b78e-30b3e7cce873.mov

**After**
https://user-images.githubusercontent.com/15018469/191556917-df1c7fc2-e31e-4ea8-954d-15e74b7754d2.mov

