### PR TITLE
Phishing warning page update more CSS suggestions

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -71,15 +71,13 @@ describe('Phishing warning page', () => {
 
   it('should render page', async () => {
     const container = window.document.getElementsByTagName('body')[0];
-    expect(
-      queryByText(container, 'MetaMask Phishing Detection'),
-    ).not.toBeNull();
+    expect(queryByText(container, 'Deceptive site ahead')).not.toBeNull();
   });
 
   it('should have correct default "New issue" link', () => {
     const newIssueLink = window.document.getElementById('new-issue-link');
-    expect(newIssueLink?.getAttribute('href')).toBe(
-      'https://github.com/metamask/eth-phishing-detect/issues/new',
+    expect(newIssueLink?.getAttribute('onclick')).toBe(
+      "window.open('https://github.com/metamask/eth-phishing-detect/issues/new')",
     );
   });
 
@@ -119,30 +117,6 @@ describe('Phishing warning page', () => {
   it.todo(
     'should add site to safelist when the user continues at their own risk',
   );
-
-  it.todo(
-    'should redirect to the site after the user continues at their own risk',
-  );
-
-  it('should show a different message if the URL contains an unsupported protocol', async () => {
-    window.document.location.href = getUrl(
-      'example.com',
-      // eslint-disable-next-line no-script-url
-      'javascript:alert("example")',
-    );
-
-    await import('./index');
-    // non-null assertion used because TypeScript doesn't know the event handler was run
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    onDomContentLoad!(new Event('DOMContentLoaded'));
-
-    const redirectWarningMessage = window.document.getElementById(
-      'redirect-warning-message',
-    );
-    expect(redirectWarningMessage?.innerText).toBe(
-      "This URL does not use a supported protocol so we won't give you the option to skip this warning.",
-    );
-  });
 
   it('should throw an error if the hostname is missing', async () => {
     window.document.location.href = getUrl(undefined, 'https://example.com');
@@ -198,5 +172,23 @@ describe('Phishing warning page', () => {
     expect(() => onDomContentLoad!(new Event('DOMContentLoaded'))).toThrow(
       'Unable to locate unsafe continue link',
     );
+  });
+
+  it('should redirect when continue to the site is clicked', async () => {
+    window.document.location.href = getUrl(
+      'example.com',
+      'https://example.com',
+    );
+
+    await import('./index');
+    // non-null assertion used because TypeScript doesn't know the event handler was run
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    onDomContentLoad!(new Event('DOMContentLoaded'));
+
+    const continueLink = document.getElementById('unsafe-continue');
+
+    continueLink?.click();
+
+    expect(global.window.location.href).toContain('example.com');
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,16 +137,6 @@ function start() {
     throw new Error('Unable to locate unsafe continue link');
   }
 
-  if (isValidSuspectHref(suspectHref) === false) {
-    const redirectWarningMessage = document.getElementById(
-      'redirect-warning-message',
-    );
-    if (redirectWarningMessage) {
-      redirectWarningMessage.innerHTML = `<br />`;
-      redirectWarningMessage.innerText = `This URL does not use a supported protocol so we won't give you the option to skip this warning.`;
-    }
-  }
-
   continueLink.addEventListener('click', async () => {
     if (isValidSuspectHref(suspectHref) === false) {
       console.log(`Disallowed Protocol, cannot continue.`);

--- a/static/index.css
+++ b/static/index.css
@@ -32,17 +32,38 @@ body {
   width: 100vw;
   height: 100vh;
 
-  background-color: var(--color-error-default);
+  background-color: #d03242;
   font-family: Euclid, Roboto, Helvetica, Arial, sans-serif;
-}
-
-p {
-  margin: 2em;
 }
 
 p a {
   text-decoration: underline;
-  color: var(--color-primary-default);
+  color: white;
+  cursor: pointer;
+}
+
+h1 {
+  color: black;
+  -webkit-text-fill-color: white;
+  -webkit-text-stroke-width: 1px;
+  -webkit-text-stroke-color: black;
+  text-shadow: 0px 4px rgba(0,0,0, 0.15);
+}
+
+ul {
+  padding-left: 2em;
+}
+
+button {
+  color: red;
+  background: white;
+  padding: 1em;
+  border-radius: 2em;
+  border: none;
+  float: right;
+  margin-top: 3em;
+  font-size: 0.9em;
+  font-family: Euclid, Roboto, Helvetica, Arial, sans-serif;
   cursor: pointer;
 }
 
@@ -51,48 +72,34 @@ p a {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  width: 80%;
-  background-color: var(--color-background-default);
-  box-shadow: 0 0 15px var(--brand-colors-grey-grey500);
+  width: 50%;
+  padding: 5rem;
 }
 
 .content__header {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: center;
   width: 100%;
   color: var(--color-error-default);
   border-bottom: 1px solid var(--color-border-default);
-  padding: 2em;
+  margin-bottom: 1rem;
 }
 
 .content__header h1 {
-  font-size: 1.5rem;
-  font-weight: normal;
+  font-size: 2rem;
+  font-weight: bold;
+  color: white;
+  float: left;
 }
 
-.content__header h1 svg {
-  margin-right: 0.25em;
-  fill: var(--color-error-default);
-  width: 1em;
-  height: 1em;
-  vertical-align: middle;
-}
-
-.content__header img {
-  margin-bottom: 3em;
-  width: 130px;
+.content__header svg {
+  fill: white;
+  width: 4em;
+  height: 4em;
+  margin-bottom: 2em;
 }
 
 .content__body {
-  background-color: var(--color-background-alternative);
   font-size: 1rem;
-  color: var(--color-text-default);
-}
-
-.content__framed-body {
-  background-color: var(--color-background-alternative);
-  font-size: 1rem;
-  color: var(--color-text-default);
+  color: white;
 }

--- a/static/index.css
+++ b/static/index.css
@@ -32,22 +32,14 @@ body {
   width: 100vw;
   height: 100vh;
 
-  background-color: #d03242;
+  background-color: var(--color-error-alternative);
   font-family: Euclid, Roboto, Helvetica, Arial, sans-serif;
 }
 
 p a {
   text-decoration: underline;
-  color: white;
+  color: var(--color-error-inverse);
   cursor: pointer;
-}
-
-h1 {
-  color: black;
-  -webkit-text-fill-color: white;
-  -webkit-text-stroke-width: 1px;
-  -webkit-text-stroke-color: black;
-  text-shadow: 0px 4px rgba(0,0,0, 0.15);
 }
 
 ul {
@@ -55,8 +47,8 @@ ul {
 }
 
 button {
-  color: red;
-  background: white;
+  color: var(--color-error-alternative);
+  background: var(--color-error-inverse);
   padding: 1em;
   border-radius: 2em;
   border: none;
@@ -80,20 +72,18 @@ button {
   display: flex;
   flex-direction: column;
   width: 100%;
-  color: var(--color-error-default);
-  border-bottom: 1px solid var(--color-border-default);
   margin-bottom: 1rem;
 }
 
 .content__header h1 {
   font-size: 2rem;
   font-weight: bold;
-  color: white;
+  color: var(--color-error-inverse);
   float: left;
 }
 
 .content__header svg {
-  fill: white;
+  fill: var(--color-error-inverse);
   width: 4em;
   height: 4em;
   margin-bottom: 2em;
@@ -101,5 +91,5 @@ button {
 
 .content__body {
   font-size: 1rem;
-  color: white;
+  color: var(--color-error-inverse);
 }

--- a/static/index.css
+++ b/static/index.css
@@ -54,8 +54,11 @@ button {
   border: none;
   float: right;
   margin-top: 3em;
-  font-size: 0.9em;
-  font-family: Euclid, Roboto, Helvetica, Arial, sans-serif;
+  font-family: var(--typography-s-body-md-font-family);
+  font-weight: var(--typography-s-body-md-font-weight);
+  font-size: var(--typography-s-body-md-font-size);
+  line-height: var(--typography-s-body-md-line-height);
+  letter-spacing: var(--typography-s-body-md-letter-spacing);
   cursor: pointer;
 }
 

--- a/static/index.css
+++ b/static/index.css
@@ -49,9 +49,9 @@ ul {
 button {
   color: var(--color-error-alternative);
   background: var(--color-error-inverse);
+  border: 1px solid var(--color-error-alternative);
   padding: 1em;
   border-radius: 2em;
-  border: none;
   float: right;
   margin-top: 3em;
   font-family: var(--typography-s-body-md-font-family);
@@ -60,6 +60,12 @@ button {
   line-height: var(--typography-s-body-md-line-height);
   letter-spacing: var(--typography-s-body-md-letter-spacing);
   cursor: pointer;
+}
+
+.button:hover{
+  color: var(--color-error-inverse);
+  background-color: var(--color-error-alternative);
+  box-shadow: var(--color-error-alternative);
 }
 
 .content {

--- a/static/index.css
+++ b/static/index.css
@@ -25,80 +25,140 @@
   box-sizing: border-box;
 }
 
-body {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  width: 100vw;
-  height: 100vh;
-
-  background-color: var(--color-error-alternative);
-  font-family: Euclid, Roboto, Helvetica, Arial, sans-serif;
+html {
+  height: 100%;
 }
 
-p a {
+body {
+  background-color: var(--color-error-alternative);
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--typography-s-body-md-font-family);
+  font-weight: var(--typography-s-body-md-font-weight);
+  font-size: var(--typography-s-body-md-font-size);
+  line-height: var(--typography-s-body-md-line-height);
+  letter-spacing: var(--typography-s-body-md-letter-spacing);
+  color: var(--color-error-inverse);
+}
+
+@media screen and (min-width: 768px) {
+  body {
+    font-family: var(--typography-l-body-md-font-family);
+    font-weight: var(--typography-l-body-md-font-weight);
+    font-size: var(--typography-l-body-md-font-size);
+    line-height: var(--typography-l-body-md-line-height);
+    letter-spacing: var(--typography-l-body-md-letter-spacing);
+  }
+}
+
+.heading-lg {
+  font-family: var(--typography-s-heading-lg-font-family);
+  font-weight: var(--typography-s-heading-lg-font-weight);
+  font-size: var(--typography-s-heading-lg-font-size);
+  line-height: var(--typography-s-heading-lg-line-height);
+  letter-spacing: var(--typography-s-heading-lg-letter-spacing);
+}
+
+@media screen and (min-width: 768px) {
+  .heading-lg {
+    font-family: var(--typography-l-heading-lg-font-family);
+    font-weight: var(--typography-l-heading-lg-font-weight);
+    font-size: var(--typography-l-heading-lg-font-size);
+    line-height: var(--typography-l-heading-lg-line-height);
+    letter-spacing: var(--typography-l-heading-lg-letter-spacing);
+  }
+}
+
+a {
   text-decoration: underline;
   color: var(--color-error-inverse);
   cursor: pointer;
 }
 
 ul {
-  padding-left: 2em;
+  padding-left: 32px;
 }
 
-button {
-  color: var(--color-error-alternative);
-  background: var(--color-error-inverse);
-  border: 1px solid var(--color-error-alternative);
-  padding: 1em;
-  border-radius: 2em;
-  float: right;
-  margin-top: 3em;
+.button-secondary {
+  color: var(--color-primary-default);
+  background: var(--color-background-default);
+  border: 1px solid var(--color-primary-default);
+  padding-right: 16px;
+  padding-left: 16px;
+  border-radius: 9999px;
+  height: 48px;
+  display: flex;
+  align-items: center;
+  margin-top: 48px;
   font-family: var(--typography-s-body-md-font-family);
   font-weight: var(--typography-s-body-md-font-weight);
   font-size: var(--typography-s-body-md-font-size);
   line-height: var(--typography-s-body-md-line-height);
   letter-spacing: var(--typography-s-body-md-letter-spacing);
   cursor: pointer;
+  margin-left: auto;
 }
 
-.button:hover{
-  color: var(--color-error-inverse);
-  background-color: var(--color-error-alternative);
-  box-shadow: var(--color-error-alternative);
+@media screen and (min-width: 768px) {
+  .button-secondary {
+    font-family: var(--typography-l-body-md-font-family);
+    font-weight: var(--typography-l-body-md-font-weight);
+    font-size: var(--typography-l-body-md-font-size);
+    line-height: var(--typography-l-body-md-line-height);
+    letter-spacing: var(--typography-l-body-md-letter-spacing);
+  }
 }
 
+.button-secondary:hover {
+  color: var(--color-primary-inverse);
+  background-color: var(--color-primary-default);
+  box-shadow: var(--component-button-primary-shadow);
+}
+
+.button-secondary:active {
+  color: var(--color-primary-inverse);
+  background-color: var(--color-primary-alternative);
+  border-color: var(--color-primary-alternative);
+}
 .content {
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  width: 50%;
-  padding: 5rem;
+  max-width: 700px;
+  padding: 24px;
 }
 
 .content__header {
   display: flex;
   flex-direction: column;
   width: 100%;
-  margin-bottom: 1rem;
+  margin-bottom: 16px;
 }
 
 .content__header h1 {
-  font-size: 2rem;
-  font-weight: bold;
-  color: var(--color-error-inverse);
-  float: left;
+  font-family: var(--typography-s-heading-lg-font-family);
+  font-weight: var(--typography-s-heading-lg-font-weight);
+  font-size: var(--typography-s-heading-lg-font-size);
+  line-height: var(--typography-s-heading-lg-line-height);
+  letter-spacing: var(--typography-s-heading-lg-letter-spacing);
+}
+
+@media screen and (min-width: 768px) {
+  .content__header h1 {
+    font-family: var(--typography-l-heading-lg-font-family);
+    font-weight: var(--typography-l-heading-lg-font-weight);
+    font-size: var(--typography-l-heading-lg-font-size);
+    line-height: var(--typography-l-heading-lg-line-height);
+    letter-spacing: var(--typography-l-heading-lg-letter-spacing);
+  }
 }
 
 .content__header svg {
   fill: var(--color-error-inverse);
-  width: 4em;
-  height: 4em;
-  margin-bottom: 2em;
-}
-
-.content__body {
-  font-size: 1rem;
-  color: var(--color-error-inverse);
+  width: 64px;
+  height: 64px;
+  margin-bottom: 24px;
 }

--- a/static/index.html
+++ b/static/index.html
@@ -75,7 +75,7 @@
       </br>
         <p>If we're flagging a legitimate website, please <a id="new-issue-link" href='' onclick="window.open('https://github.com/metamask/eth-phishing-detect/issues/new')">report a detection problem.</a></p>
         <p>If you understand the risks and still want to proceed, you can <a id="unsafe-continue">continue to the site.</a></p>
-        <button class="button btn--rounded btn-primary" type="submit" onclick="window.close()">Back to safety</button>
+        <button class="button-secondary" type="submit" onclick="window.close()">Back to safety</button>
       </div>
     </div>
   </body>

--- a/static/index.html
+++ b/static/index.html
@@ -13,7 +13,7 @@
       }
 
       window.onload = function() {
-        document.getElementById("suspect-link").innerHTML = document.referrer;
+        document.getElementById("suspect-link").innerText = document.referrer;
       }
     </script>
     <title>MetaMask Phishing Detection</title>
@@ -43,7 +43,6 @@
       charset="utf-8"
     ></script>
     <link rel="stylesheet" type="text/css" href="./design-tokens.css">
-    <link rel="stylesheet" href="https://raw.githubusercontent.com/MetaMask/design-tokens/main/src/css/design-tokens.css">
     <link rel="stylesheet" type="text/css" href="./index.css">
     <link rel="icon" href="./favicon.ico" sizes="any"><!-- 32×32 -->
     <link rel="icon" href="./metamask-fox.svg" type="image/svg+xml">

--- a/static/index.html
+++ b/static/index.html
@@ -11,6 +11,10 @@
         document.getElementById('antiClickjack').innerHTML =
           '#content__framed-body { display: none !important; }';
       }
+
+      window.onload = function() {
+        document.getElementById("suspect-link").innerHTML = document.referrer;
+      }
     </script>
     <title>MetaMask Phishing Detection</title>
     <script
@@ -46,67 +50,32 @@
   <body>
     <div class="content">
       <div class="content__header">
-        <img src="./metamask-fox.svg" alt="MetaMask Logo" />
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--! Font Awesome Pro 6.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. -->
+          <path d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7 .2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8 .2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24V296c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32s14.3 32 32 32s32-14.3 32-32z"/>
+        </svg>
         <h1>
-         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" preserveAspectRatio="xMidYMid meet"><!-- Font Awesome Pro 5.15.4 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) --><path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"/></svg>
-         MetaMask Phishing Detection
+          Deceptive site ahead
         </h1>
       </div>
       <div id="content__body" class="content__body">
         <p>
-          This domain is currently on the MetaMask domain warning list. This
-          means that based on information available to us, MetaMask believes
-          this domain could currently compromise your security and, as an added
-          safety feature, MetaMask has restricted access to the site. To
-          override this, please read the rest of this warning for instructions
-          on how to continue at your own risk.
+          MetaMask flagged the site you're trying to visit as potentially deceptive. Attackers may trick you into doing something dangerous. <a id="csdbLink" href='' onclick="window.open('https://cryptoscamdb.org/search')">Learn more</a>
         </p>
-        <p>
-          There are many reasons sites can appear on our warning list, and our
-          warning list compiles from other widely used industry lists. Such
-          reasons can include known fraud or security risks, such as domains
-          that test positive on the
-          <a href="https://github.com/metamask/eth-phishing-detect"
-            >Ethereum Phishing Detector</a
-          >. Domains on these warning lists may include outright malicious
-          websites and legitimate websites that have been compromised by a
-          malicious actor.
+      </br>
+        <p>Potential threats on <span id="suspect-link"></span> include:
+          <ul>
+            <li>Fake versions of MetaMask</li>
+            <li>Secret Recovery Phrase or password theft</li>
+            <li>Malicious transactions resulting in stolen assets </li>
+          </ul>
         </p>
-        <p>
-          To read more about this site
-          <a id="csdbLink" href="https://cryptoscamdb.org/search"
-            >please search for the domain on CryptoScamDB</a
-          >.
-        </p>
-        <p>
-          Note that this warning list is compiled on a voluntary basis. This
-          list may be inaccurate or incomplete. Just because a domain does not
-          appear on this list is not an implicit guarantee of that domain's
-          safety. As always, your transactions are your own responsibility. <span id="redirect-warning-message">If
-          you wish to interact with any domain on our warning list, you can do
-          so by <a id="unsafe-continue">continuing at your own risk</a>.</span>
-        </p>
-        <p>
-          If you think this domain is incorrectly flagged or if a blocked
-          legitimate website has resolved its security issues,
-          <a
-            id="new-issue-link"
-            href="https://github.com/metamask/eth-phishing-detect/issues/new"
-            >please file an issue</a
-          >.
-        </p>
-      </div>
-      <div id="content__framed-body" class="content__framed-body">
-        <p>
-          This domain is currently on the MetaMask domain warning list. This
-          means that based on information available to us, MetaMask believes
-          this domain could currently compromise your security and, as an added
-          safety feature, MetaMask has restricted access to the site.
-        </p>
-        <p>
-          <a id="open-self-in-new-tab" target="_blank">Open this warning in a new tab</a> for more information
-          on why this domain is blocked, and how to continue at your own risk.
-        </p>
+      </br>
+        <p>Advisory provided by Ethereum Phishing Detector, CryptoScamDB, and PhishFort.</p>
+      </br>
+      </br>
+        <p>If we're flagging a legitimate website, please <a id="new-issue-link" href='' onclick="window.open('https://github.com/metamask/eth-phishing-detect/issues/new')">report a detection problem.</a></p>
+        <p>If you understand the risks and still want to proceed, you can <a id="unsafe-continue">continue to the site.</a></p>
+        <button class="button btn--rounded btn-primary" type="submit" onclick="window.close()">Back to safety</button>
       </div>
     </div>
   </body>

--- a/static/index.html
+++ b/static/index.html
@@ -43,6 +43,7 @@
       charset="utf-8"
     ></script>
     <link rel="stylesheet" type="text/css" href="./design-tokens.css">
+    <link rel="stylesheet" href="https://raw.githubusercontent.com/MetaMask/design-tokens/main/src/css/design-tokens.css">
     <link rel="stylesheet" type="text/css" href="./index.css">
     <link rel="icon" href="./favicon.ico" sizes="any"><!-- 32×32 -->
     <link rel="icon" href="./metamask-fox.svg" type="image/svg+xml">


### PR DESCRIPTION
# DO NOT MERGE TO `main`

### Descriptions
Some more updates built on New design for phishing warning page PR https://github.com/MetaMask/phishing-warning/pull/52. The intention is for the updates in this commit https://github.com/MetaMask/phishing-warning/pull/55/commits/ad6abc58871830ec4b4010e89c624b7d6b43aee4 to be based on the [original PR](https://github.com/MetaMask/phishing-warning/pull/52) https://github.com/MetaMask/phishing-warning/pull/52 but I'm not sure how to do that seeing as it's a forked branch. 

- Adds more design system CSS variables
- Adds medai query support 
- Graceful degradation on smaller screens
- Updates button css to use secondary styles

## Screenshots

### Before


https://user-images.githubusercontent.com/8112138/216879699-77ce65b1-ee7d-4c25-915e-6f66bfe0aa1d.mov

### After


https://user-images.githubusercontent.com/8112138/216879735-1408fbab-f596-42ee-9877-0d225152de76.mov

### Manual Testing Steps

- For local testing update line `45` to import the design-token.css from the npm packge 
- Update `href="./design-tokens.css"` to `href="../node_modules/@metamask/design-tokens/src/css/design-tokens.css"`