### PR TITLE
Dynamically lookup the source of a block

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,9 +25,12 @@
   "dependencies": {
     "@metamask/design-tokens": "^1.6.0",
     "@metamask/post-message-stream": "^6.0.0",
+    "@types/punycode": "^2.1.0",
+    "eth-phishing-detect": "^1.2.0",
     "globalthis": "1.0.1",
     "obj-multiplex": "^1.0.0",
     "pump": "^3.0.0",
+    "punycode": "^2.1.1",
     "ses": "^0.18.1"
   },
   "devDependencies": {

--- a/static/index.html
+++ b/static/index.html
@@ -69,7 +69,7 @@
         <p>Advisory provided by <span id="detection-repo">Ethereum Phishing Detector and PhishFort</span>.</p>
       </br>
       </br>
-        <p>If we're flagging a legitimate website, please <a id="new-issue-link" rel="noopener" target='_blank' href="https://github.com/metamask/eth-phishing-detect/issues/new">report a detection problem.</a></p>
+        <p>If we're flagging a legitimate website, please <a id="new-issue-link" href="#">report a detection problem.</a></p>
         <p>If you understand the risks and still want to proceed, you can <a id="unsafe-continue">continue to the site.</a></p>
         <button class="button-secondary" type="submit" onclick="window.close()">Back to safety</button>
       </div>

--- a/tests/defaults.spec.ts
+++ b/tests/defaults.spec.ts
@@ -34,20 +34,6 @@ test('shows an empty list of detection projects', async ({ page }) => {
   );
 });
 
-test('directs users to eth-phishing-detect to dispute a block', async ({
-  page,
-}) => {
-  await page.goto('/');
-
-  const popupPromise = page.waitForEvent('popup');
-  await page.getByRole('link', { name: 'report a detection problem' }).click();
-  const popup = await popupPromise;
-
-  await expect(popup).toHaveURL(
-    'https://github.com/metamask/eth-phishing-detect/issues/new',
-  );
-});
-
 test('opens CryptoScamDB in a new tab', async ({ page }) => {
   await page.goto('/');
 

--- a/tests/failed-lookup.spec.ts
+++ b/tests/failed-lookup.spec.ts
@@ -1,36 +1,22 @@
 import { test, expect } from '@playwright/test';
 import { setupDefaultMocks } from './helpers/default-mocks';
 
-test.beforeEach(async ({ context }) => {
-  await setupDefaultMocks(context);
-});
-
 test('directs users to eth-phishing-detect to dispute a block, including issue template parameters', async ({
+  context,
   page,
 }) => {
+  await setupDefaultMocks(context, { phishingError: true });
   const querystring = new URLSearchParams({
     hostname: 'test.com',
     href: 'https://test.com',
   });
   await page.goto(`/#${querystring}`);
 
-  const popupPromise = page.waitForEvent('popup');
   await page.getByRole('link', { name: 'report a detection problem' }).click();
-  const popup = await popupPromise;
+  // Wait for dynamic configuration check
+  await page.waitForLoadState('networkidle');
 
-  await expect(popup).toHaveURL(
+  await expect(page).toHaveURL(
     'https://github.com/MetaMask/eth-phishing-detect/issues/new?title=[Legitimate%20Site%20Blocked]%20test.com&body=https%3A%2F%2Ftest.com',
-  );
-});
-
-test('credits Ethereum Phishing Detector for the block', async ({ page }) => {
-  const querystring = new URLSearchParams({
-    hostname: 'test.com',
-    href: 'https://test.com',
-  });
-  await page.goto(`/#${querystring}`);
-
-  await expect(page.locator('css=#detection-repo')).toHaveText(
-    'Ethereum Phishing Detector',
   );
 });

--- a/tests/helpers/default-mocks.ts
+++ b/tests/helpers/default-mocks.ts
@@ -1,3 +1,5 @@
+import type { BrowserContext } from '@playwright/test';
+
 const emptyHtmlPage = `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -8,17 +10,49 @@ const emptyHtmlPage = `<!DOCTYPE html>
   </body>
 </html>`;
 
+export const defaultPhishingConfig: {
+  version: number;
+  tolerance: number;
+  fuzzylist: string[];
+  whitelist: string[];
+  blacklist: string[];
+} = {
+  version: 2,
+  tolerance: 2,
+  fuzzylist: [],
+  whitelist: [],
+  blacklist: [],
+};
+
 /**
  * Setup default network mocks for Playwright tests.
  *
  * @param context - The browsing context.
+ * @param options - Additional mock options.
+ * @param options.phishingConfig - The phishing configuration to return.
+ * @param options.phishingError - Whether to return an error for the phishing configuration.
  */
-export async function setupDefaultMocks(context) {
+export async function setupDefaultMocks(
+  context: BrowserContext,
+  { phishingConfig = defaultPhishingConfig, phishingError = false } = {},
+) {
   await context.route('https://github.com/**/*', (route) =>
     route.fulfill({
       body: emptyHtmlPage,
       contentType: 'text/html',
     }),
+  );
+
+  await context.route(
+    'https://raw.githubusercontent.com/MetaMask/eth-phishing-detect/master/src/config.json',
+    (route) =>
+      route.fulfill(
+        phishingError
+          ? { status: 500 }
+          : {
+              json: phishingConfig,
+            },
+      ),
   );
 
   await context.route('https://cryptoscamdb.org/**/*', (route) =>

--- a/tests/invalid-inputs.spec.ts
+++ b/tests/invalid-inputs.spec.ts
@@ -51,6 +51,16 @@ test('throws an error about the href query parameter being missing', async ({
   );
 });
 
+test('ignores attempts to dispute a block', async ({ page }) => {
+  await page.goto('/');
+
+  await page.getByRole('link', { name: 'report a detection problem' }).click();
+  // Wait for dynamic configuration check
+  await page.waitForLoadState('networkidle');
+
+  await expect(page).toHaveURL('/#');
+});
+
 test('does not allow user to bypass warning for invalid protocols', async ({
   page,
 }) => {

--- a/tests/metamask-block.spec.ts
+++ b/tests/metamask-block.spec.ts
@@ -1,38 +1,49 @@
 import { test, expect } from '@playwright/test';
-import { setupDefaultMocks } from './helpers/default-mocks';
-
-test.beforeEach(async ({ context }) => {
-  await setupDefaultMocks(context);
-});
+import {
+  defaultPhishingConfig,
+  setupDefaultMocks,
+} from './helpers/default-mocks';
 
 test('directs users to eth-phishing-detect to dispute a block, including issue template parameters', async ({
+  context,
   page,
 }) => {
+  await setupDefaultMocks(context, {
+    phishingConfig: { ...defaultPhishingConfig, blacklist: ['test.com'] },
+  });
   const querystring = new URLSearchParams({
     hostname: 'test.com',
     href: 'https://test.com',
-    newIssueUrl: 'https://github.com/MetaMask/eth-phishing-detect/issues/new',
   });
   await page.goto(`/#${querystring}`);
 
-  const popupPromise = page.waitForEvent('popup');
   await page.getByRole('link', { name: 'report a detection problem' }).click();
-  const popup = await popupPromise;
+  // Wait for dynamic configuration check
+  await page.waitForLoadState('networkidle');
 
-  await expect(popup).toHaveURL(
+  await expect(page).toHaveURL(
     'https://github.com/MetaMask/eth-phishing-detect/issues/new?title=[Legitimate%20Site%20Blocked]%20test.com&body=https%3A%2F%2Ftest.com',
   );
 });
 
-test('credits Ethereum Phishing Detector for the block', async ({ page }) => {
+test('correctly matches unicode domains', async ({ context, page }) => {
+  await setupDefaultMocks(context, {
+    phishingConfig: {
+      ...defaultPhishingConfig,
+      blacklist: ['xn--metamsk-en4c.io'],
+    },
+  });
   const querystring = new URLSearchParams({
     hostname: 'test.com',
-    href: 'https://test.com',
-    newIssueUrl: 'https://github.com/MetaMask/eth-phishing-detect/issues/new',
+    href: 'https://metamạsk.io',
   });
   await page.goto(`/#${querystring}`);
 
-  await expect(page.locator('css=#detection-repo')).toHaveText(
-    'Ethereum Phishing Detector',
+  await page.getByRole('link', { name: 'report a detection problem' }).click();
+  // Wait for dynamic configuration check
+  await page.waitForLoadState('networkidle');
+
+  await expect(page).toHaveURL(
+    'https://github.com/MetaMask/eth-phishing-detect/issues/new?title=[Legitimate%20Site%20Blocked]%20test.com&body=https%3A%2F%2Fmetamạsk.io',
   );
 });

--- a/tests/phishfort-block.spec.ts
+++ b/tests/phishfort-block.spec.ts
@@ -11,26 +11,14 @@ test('directs users to PhishFort to dispute a block, including issue template pa
   const querystring = new URLSearchParams({
     hostname: 'test.com',
     href: 'https://test.com',
-    newIssueUrl: 'https://github.com/phishfort/phishfort-lists/issues/new',
   });
   await page.goto(`/#${querystring}`);
 
-  const popupPromise = page.waitForEvent('popup');
   await page.getByRole('link', { name: 'report a detection problem' }).click();
-  const popup = await popupPromise;
+  // Wait for dynamic configuration check
+  await page.waitForLoadState('networkidle');
 
-  await expect(popup).toHaveURL(
+  await expect(page).toHaveURL(
     'https://github.com/phishfort/phishfort-lists/issues/new?title=[Legitimate%20Site%20Blocked]%20test.com&body=https%3A%2F%2Ftest.com',
   );
-});
-
-test('credits PhishFort for the block', async ({ page }) => {
-  const querystring = new URLSearchParams({
-    hostname: 'test.com',
-    href: 'https://test.com',
-    newIssueUrl: 'https://github.com/phishfort/phishfort-lists/issues/new',
-  });
-  await page.goto(`/#${querystring}`);
-
-  await expect(page.locator('css=#detection-repo')).toHaveText('PhishFort');
 });

--- a/types/eth-phishing-detect/src/detector.d.ts
+++ b/types/eth-phishing-detect/src/detector.d.ts
@@ -1,0 +1,1 @@
+declare module 'eth-phishing-detect/src/detector';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1675,6 +1675,7 @@ __metadata:
     "@testing-library/user-event": ^14.1.1
     "@types/node": ^17.0.23
     "@types/pump": ^1.1.1
+    "@types/punycode": ^2.1.0
     "@types/readable-stream": ^2.3.13
     "@typescript-eslint/eslint-plugin": ^4.33.0
     "@typescript-eslint/parser": ^4.33.0
@@ -1686,6 +1687,7 @@ __metadata:
     eslint-plugin-jsdoc: ^36.1.0
     eslint-plugin-node: ^11.1.0
     eslint-plugin-prettier: ^3.4.1
+    eth-phishing-detect: ^1.2.0
     exorcist: ^2.0.0
     fs-extra: ^10.1.0
     globalthis: 1.0.1
@@ -1696,6 +1698,7 @@ __metadata:
     prettier: ^2.6.2
     prettier-plugin-packagejson: ^2.2.17
     pump: ^3.0.0
+    punycode: ^2.1.1
     ses: ^0.18.1
     terser: ^5.13.1
     ts-node: ^10.7.0
@@ -2032,6 +2035,13 @@ __metadata:
   dependencies:
     "@types/node": "*"
   checksum: dd4a1485f2f6052cacb71a94b48d9f360e07a2fc3fac03782ae4caa9856e6df7017ee89515d70ecefcfe281553311cde4a3748219c9fcd757fdb77f3a47e0f29
+  languageName: node
+  linkType: hard
+
+"@types/punycode@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@types/punycode@npm:2.1.0"
+  checksum: 6835698becab395eb9ac186970fd7879aeb522ea72d516ef9d681d787989653fcc2439ecc07d48280e1ca11862773b806efeec3fdbd1207528829a83b65d4275
   languageName: node
   linkType: hard
 
@@ -4055,6 +4065,15 @@ __metadata:
   version: 2.0.3
   resolution: "esutils@npm:2.0.3"
   checksum: 22b5b08f74737379a840b8ed2036a5fb35826c709ab000683b092d9054e5c2a82c27818f12604bfc2a9a76b90b6834ef081edbc1c7ae30d1627012e067c6ec87
+  languageName: node
+  linkType: hard
+
+"eth-phishing-detect@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "eth-phishing-detect@npm:1.2.0"
+  dependencies:
+    fast-levenshtein: ^2.0.6
+  checksum: 66a6a7c249ec8494e0360663596ce980ca75747cd202c47732eca0bfc7a97c6debbae359842e4f3e4ac7e6c44ab1f7f091c3aa7baa330449d3c1b7cc58608b71
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
When a user chooses to dispute a block, we now dynamically lookup the source of the block instead of getting the dispute URL from the query parameters. This is in preparation for an extension update that will necessitate dropping the `newIssueUrl` query parameter we had previously been relying on.

This is a temporary measure. A future update will restore the source for each block. At that time we can revert this change.

This should be comparing in exactly the same way as the extension. The configuration is fetched dynamically so it may be slightly more up-to-date than what the extension is using.