### PR TITLE
Fix release publishing

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -18,4 +18,4 @@ jobs:
           node-version-file: '.nvmrc'
       - uses: MetaMask/action-publish-release@v2
         env:
-          GITHUB_TOKEN: ${{ secrets.METAMASKBOT_PUBLISH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The recent GitHub Actions changes in #63 broke the last step of the release process, where the GitHub Release (and git tag) was created. It failed because we were using a custom token to publish the release, and it wasn't being properly passed through the `workflow_dispatch` call.

We don't actually need any special token for this step, we can use the built-in `GITHUB_TOKEN` instead. The workflow has been updated to do that.