### PR TITLE
Stop running tests in `prepack`

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lint:eslint": "eslint . --cache --ext js,ts",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' '**/*.yml' '!.yarnrc.yml' --ignore-path .gitignore --no-error-on-unmatched-pattern",
-    "prepack": "yarn build:prod && yarn lint && yarn test",
+    "prepack": "yarn build:prod && yarn lint",
     "setup": "yarn install && yarn allow-scripts",
     "start": "yarn build && yarn http-server ./dist",
     "test": "yarn playwright test"


### PR DESCRIPTION
The `test` command is no longer run as part of `prepack`. This was included back when `test` was for unit tests, when it was short and simple enough to run as part of publishing. Now that it runs e2e tests across 4 different browsers, it no longer makes sense.