### PR TITLE
Restore iframe warning and "open in new tab" link

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -73,6 +73,15 @@
         <p>If you understand the risks and still want to proceed, you can <a id="unsafe-continue">continue to the site.</a></p>
         <button class="button-secondary" type="submit" onclick="window.close()">Back to safety</button>
       </div>
+      <div id="content__framed-body" class="content__framed-body">
+        <p>
+          MetaMask flagged the site you're trying to visit as potentially deceptive. Attackers may trick you into doing something dangerous.
+        </p>
+        <p>
+          <a id="open-self-in-new-tab" target="_blank">Open this warning in a new tab</a> for more information
+          on why this domain is blocked, and how to continue at your own risk.
+        </p>
+      </div>
     </div>
   </body>
 </html>

--- a/tests/iframe.spec.ts
+++ b/tests/iframe.spec.ts
@@ -44,14 +44,27 @@ test.beforeEach(async ({ context }) => {
 });
 
 test('does not allow the user to bypass the warning', async ({ page }) => {
-  await expect(await page.getByRole('button').all()).toStrictEqual([]);
-  await expect(await page.getByRole('checkbox').all()).toStrictEqual([]);
-  await expect(await page.getByRole('combobox').all()).toStrictEqual([]);
-  await expect(await page.getByRole('link').all()).toStrictEqual([]);
+  const iframe = await page.frameLocator('#embedded-warning');
+  await expect(await iframe.getByRole('button').count()).toBe(0);
+  await expect(
+    await iframe.getByRole('link', { name: 'continue to the site' }).count(),
+  ).toBe(0);
 });
 
-test('does not link to any external page', async ({ page }) => {
-  await expect(await page.getByRole('link').all()).toStrictEqual([]);
+test('only shows one link, which is to open the same warning in a new tab', async ({
+  page,
+}) => {
+  const links = await page
+    .frameLocator('#embedded-warning')
+    .getByRole('link')
+    .all();
+  const hrefs = await Promise.all(
+    links.map((locator) => locator.getAttribute('href')),
+  );
+
+  expect(hrefs).toStrictEqual([
+    'http://localhost:8080/#hostname=test.com&href=https%3A%2F%2Ftest.com',
+  ]);
 });
 
 test('opens the warning in a new tab with valid inputs preserved', async ({


### PR DESCRIPTION
The "Open in new tab" link that we show on the warning page when it's rendered in an iframe was accidentally removed in #52. We need to preserve this button so that users can better understand why their iframe'd page is blocked, and so they can dispute or bypass the block if necessary.