### PR TITLE
Add GitHub workflow for publishing RC

### DIFF
--- a/.github/workflows/manually-publish-release-gh-pages.yml
+++ b/.github/workflows/manually-publish-release-gh-pages.yml
@@ -1,0 +1,25 @@
+name: Manually publish release candidate to GitHub Pages
+
+on:
+  workflow_dispatch:
+    inputs:
+      release-candidate-version:
+        description: 'The release candidate version to publish'
+        default: 'rc-v1.1.0'
+        type: choice
+        options:
+          - rc-v1.1.0
+          - rc-v1.2.0
+          - rc-v1.2.1
+          - rc-v1.2.2
+          - rc-v2.0.0
+        required: true
+
+jobs:
+  patch-github-pages:
+    name: Publish build to `${{ github.event.inputs.release-candidate-version }}` directory of `gh-pages` branch
+    permissions:
+      contents: write
+    uses: ./.github/workflows/publish-gh-pages.yml
+    with:
+      destination_dir: ${{ github.event.inputs.release-candidate-version }}


### PR DESCRIPTION
## Problem

We currently do not have a way to patch old versions of the phishing warning page which already have releases. This is due to the fact that the way we publish a release candidate is by listening for a release to be tagged, ex: `v3.0.0` then publishing the release candidate under `https://metamask.github.io/phishing-warning/v3.0.0/`. 

However, because of this, if we want to make an invisible patch to v3.0.0 we can't due to the fact that we can't tag a second `v3.0.0` release.

## Solution

Add a GitHub action that lets you specify a release candidate to publish, and manually publish it. 

## Caviats

This makes change management tricky as the process for these invisible updates (typically security) becomes:

* Create a PR against a `release/<version>` branch. 
* Get approvals then merge
* Manually publish the new release using GH action
* Open a second PR against `main` updating the changelog for that version

We will also need branch protection for pushes to release branches as they are capable of automatically publishing to GitHub pages