### PR TITLE
fix(18194): fix trigger to close window when clicking "back to safety"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,9 @@ node_modules/
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
 
+# intellij config files
+/.idea
+
 # yarn v3 (w/o zero-install)
 # See: https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored
 .pnp.*

--- a/src/index.ts
+++ b/src/index.ts
@@ -194,7 +194,7 @@ function start() {
   }
 
   continueLink.addEventListener('click', async () => {
-    if (isValidSuspectHref(suspectHref) === false) {
+    if (!isValidSuspectHref(suspectHref)) {
       console.log(`Disallowed Protocol, cannot continue.`);
       return;
     }
@@ -207,5 +207,19 @@ function start() {
     });
 
     window.location.href = suspectHref;
+  });
+
+  const backToSafetyLink = document.getElementById('back-to-safety');
+  if (!backToSafetyLink) {
+    throw new Error('Unable to locate back to safety link');
+  }
+
+  backToSafetyLink.addEventListener('click', async () => {
+    phishingSafelistStream.write({
+      jsonrpc: '2.0',
+      method: 'backToSafetyPhishingWarning',
+      params: [],
+      id: createRandomId(),
+    });
   });
 }

--- a/static/index.html
+++ b/static/index.html
@@ -71,7 +71,7 @@
       </br>
         <p>If we're flagging a legitimate website, please <a id="new-issue-link" href="#">report a detection problem.</a></p>
         <p>If you understand the risks and still want to proceed, you can <a id="unsafe-continue">continue to the site.</a></p>
-        <button class="button-secondary" type="submit" onclick="window.close()">Back to safety</button>
+        <button class="button-secondary" type="submit" onclick="window.open('location', '_self', '');window.close();">Back to safety</button>
       </div>
       <div id="content__framed-body" class="content__framed-body">
         <p>

--- a/static/index.html
+++ b/static/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang='en' xmlns:about='http://www.w3.org/1999/xhtml'>
   <head>
     <style id="antiClickjack">
       #content__body {
@@ -71,7 +71,7 @@
       </br>
         <p>If we're flagging a legitimate website, please <a id="new-issue-link" href="#">report a detection problem.</a></p>
         <p>If you understand the risks and still want to proceed, you can <a id="unsafe-continue">continue to the site.</a></p>
-        <button class="button-secondary" type="submit" onclick="window.open('location', '_self', '');window.close();">Back to safety</button>
+        <button class="button-secondary" type="submit" onclick='location.replace("about:blank")'>Back to safety</button>
       </div>
       <div id="content__framed-body" class="content__framed-body">
         <p>

--- a/static/index.html
+++ b/static/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang='en' xmlns:about='http://www.w3.org/1999/xhtml'>
+<html lang="en">
   <head>
     <style id="antiClickjack">
       #content__body {
@@ -71,7 +71,7 @@
       </br>
         <p>If we're flagging a legitimate website, please <a id="new-issue-link" href="#">report a detection problem.</a></p>
         <p>If you understand the risks and still want to proceed, you can <a id="unsafe-continue">continue to the site.</a></p>
-        <button class="button-secondary" type="submit" onclick='location.replace("about:blank")'>Back to safety</button>
+        <button class="button-secondary" type="submit" id="back-to-safety">Back to safety</button>
       </div>
       <div id="content__framed-body" class="content__framed-body">
         <p>

--- a/tests/defaults.spec.ts
+++ b/tests/defaults.spec.ts
@@ -55,7 +55,7 @@ test('does nothing when the user tries to bypass the warning', async ({
   await expect(page.isClosed()).toBe(false);
 });
 
-test('closes the window when the user clicks "Back to safety"', async ({
+test('replaces tab with a new blank page when the user clicks "Back to safety"', async ({
   page,
 }) => {
   // Calling `replace` here instead of `goto` to ensure that the page loads with a browser history
@@ -65,10 +65,10 @@ test('closes the window when the user clicks "Back to safety"', async ({
   const baseURL = config.use?.baseURL;
   await page.evaluate((url) => window.location.replace(url), `${baseURL}/`);
 
-  const onClose = page.waitForEvent('close');
+  const onReloadNewBlankPage = page.waitForURL('about:blank');
   await page.getByRole('button', { name: 'Back to safety' }).click();
 
-  await onClose;
+  await onReloadNewBlankPage;
 });
 
 test('logs that the service worker is registered', async ({ page }) => {


### PR DESCRIPTION
**Fixes**: https://app.zenhub.com/workspaces/extension-client-team-63529dce65cbb100265a3842/issues/gh/metamask/metamask-extension/18194

 **Before**: 
- [user visits blocked page] -> [window.location.href = "warning page URL" in contentScript]  -> [warning page] -> [user clicks "Back to safety"] -> [ window.close() ] -> not working in Firefox 

**Trials**: 

- [user visits blocked page] -> [ location.href = "warning page URL" ]  -> [warning page] -> [user clicks "Back to safety"] -> [window.open('location', '_self', '');window.close();] -> not working for Firefox

- [user visits blocked page] -> [window.location.replace("warning page URL") ] -> [warning page] -> [user clicks "Back to safety"] -> [window.close() ] -> not working for Firefox 

- [user visits blocked page] -> [window.location.hrer("warning page URL") ] -> [warning page] -> [user clicks "Back to safety"] -> [open a new blank page] -> [document.visibilitystate === hidden, detect user has left previous warning page] -> [window.close() inactive page] -> not working for Firefox 

**Temporary solution:**
- [user visits blocked page] -> [ location.href = "warning page URL" ]  -> [warning page] -> [user clicks "Back to safety"] -> [ location.replace("about:blank") ] -> page stays open on blank tab, works for both browsers 

Proposed by @danjm :
**- [user visits blocked page] -> [ location.href = "warning page URL" ]  -> [warning page] -> [user clicks "Back to safety"] -> [ location.replace(MM extension expanded view)] -> page stays open on a specific route, works for both browsers** 


**After**: 

https://user-images.githubusercontent.com/12678455/228697448-b548cce1-efd8-4753-9b88-8d134569dc11.mov



