### PR TITLE
Include `v` prefix in path for releases

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -93,9 +93,9 @@ jobs:
 
   publish-release-to-gh-pages:
     needs: get-release-version
-    name: Publish site to `${{ needs.get-release-version.outputs.RELEASE_VERSION }}` directory of `gh-pages` branch
+    name: Publish site to `v${{ needs.get-release-version.outputs.RELEASE_VERSION }}` directory of `gh-pages` branch
     permissions:
       contents: write
     uses: ./.github/workflows/publish-gh-pages.yml
     with:
-      destination_dir: ${{ needs.get-release-version.outputs.RELEASE_VERSION }}
+      destination_dir: v${{ needs.get-release-version.outputs.RELEASE_VERSION }}


### PR DESCRIPTION
The publishing automation has been updated to include a `v` prefix in the path for release builds. This prefix was accidentally dropped in some recent updates to the GitHub Action workflows (#63, #71).