### PR TITLE
deps: Bump all dependencies 

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "yarn playwright test"
   },
   "dependencies": {
-    "@metamask/design-tokens": "^1.6.0",
+    "@metamask/design-tokens": "^1.12.0",
     "@metamask/post-message-stream": "^6.2.0",
     "eth-phishing-detect": "^1.2.0",
     "globalthis": "1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1660,7 +1660,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/design-tokens@npm:^1.6.0":
+"@metamask/design-tokens@npm:^1.12.0":
   version: 1.12.0
   resolution: "@metamask/design-tokens@npm:1.12.0"
   checksum: 9b6c5485c846171aa7fcef03cbe93b4d94ffaa76faf953aa27a689fd3d494438cd657de6ea1aa5a40cc2af15dcf10f8dd860fd3d90f5e9806807e37020bdccd9
@@ -1714,7 +1714,7 @@ __metadata:
     "@babel/preset-typescript": ^7.16.7
     "@lavamoat/allow-scripts": ^2.3.0
     "@metamask/auto-changelog": ^3.0.0
-    "@metamask/design-tokens": ^1.6.0
+    "@metamask/design-tokens": ^1.12.0
     "@metamask/eslint-config": ^9.0.0
     "@metamask/eslint-config-nodejs": ^9.0.0
     "@metamask/eslint-config-typescript": ^9.0.1
@@ -6762,14 +6762,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"punycode@npm:^2.1.0, punycode@npm:^2.1.1":
-  version: 2.1.1
-  resolution: "punycode@npm:2.1.1"
-  checksum: 823bf443c6dd14f669984dea25757b37993f67e8d94698996064035edd43bed8a5a17a9f12e439c2b35df1078c6bec05a6c86e336209eb1061e8025c481168e8
-  languageName: node
-  linkType: hard
-
-"punycode@npm:^2.3.0":
+"punycode@npm:^2.1.0, punycode@npm:^2.1.1, punycode@npm:^2.3.0":
   version: 2.3.0
   resolution: "punycode@npm:2.3.0"
   checksum: 39f760e09a2a3bbfe8f5287cf733ecdad69d6af2fe6f97ca95f24b8921858b91e9ea3c9eeec6e08cede96181b3bb33f95c6ffd8c77e63986508aa2e8159fa200


### PR DESCRIPTION
- Bump all runtime dependencies. Makes sure users have latest security- and bug fixes.
  - Retains pinning of `globalthis@1.0.1`
- Move `@types/punycode` from `dependencies` to `devDependencies`


#### Blocking
- #106 
  - #104 
  - #107 