### PR TITLE
Action allowing us to publish backported changes

### DIFF
--- a/.github/workflows/publish-gh-pages-backport.yml
+++ b/.github/workflows/publish-gh-pages-backport.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 env:
-  BASE_REF: v2.0.1-from-tag
+  BASE_REF: v2.0.1-with-backported-fixes
   VERSIONS: v1.0.0,v1.1.0,v1.2.1,v1.2.2,v2.0.0,v2.0.1,v2.1.0
 jobs:
   publish-to-gh-pages:


### PR DESCRIPTION
We're using hardcoded build source references and target versions to ensure we have clear control over what gets deployed where. This action is tailored to only create pull requests against the gh-pages branch.

example action run:
[https://github.com/witmicko/phishing-warning/actions/runs/7033539537](https://github.com/witmicko/phishing-warning/actions/runs/7033539537)
it builds and commits changes to `gh-pages-backport` branch, I then manually created this PR
[https://github.com/witmicko/phishing-warning/pull/1](https://github.com/witmicko/phishing-warning/pull/1)