### PR TITLE
Update publish-gh-pages-backport.yml

### DIFF
--- a/.github/workflows/publish-gh-pages-backport.yml
+++ b/.github/workflows/publish-gh-pages-backport.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   BASE_REF: v2.0.1-with-backported-fixes
-  VERSIONS: v1.0.0,v1.1.0,v1.2.1,v1.2.2,v2.0.0,v2.0.1,v2.1.0
+  VERSIONS: v1.0.0,v1.1.0,v1.2.1,v1.2.2,v2.0.0,v2.0.1
 jobs:
   publish-to-gh-pages:
     name: Publish to GitHub Pages


### PR DESCRIPTION
Removing 2.1.0 at it isnt compatible with older ones