### PR TITLE
chore: Update `ses`

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "globalthis": "1.0.1",
     "punycode": "^2.3.1",
     "readable-stream": "^3.6.2",
-    "ses": "^0.18.8"
+    "ses": "^1.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.22.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1396,10 +1396,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@endo/env-options@npm:^0.1.4":
-  version: 0.1.4
-  resolution: "@endo/env-options@npm:0.1.4"
-  checksum: 6099f0a6b700a60bee7b226aa2a39bb5748e22f25e9606d70e5a66a8e62cbd8c972b0fe578735a658f80bf2ebece62e28c20aa3f16417cbfe6c19a8689966dd3
+"@endo/env-options@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@endo/env-options@npm:1.1.0"
+  checksum: 799ec765791ed69dd099a998fedb9a6a415236ce45748b06f097973542b133e3c3a296f61f0404a79119c6ae92a3f7fbc12d2cc10b1b07901bc64d4ae4d3b6ee
   languageName: node
   linkType: hard
 
@@ -1685,7 +1685,7 @@ __metadata:
     prettier-plugin-packagejson: ^2.2.17
     punycode: ^2.3.1
     readable-stream: ^3.6.2
-    ses: ^0.18.8
+    ses: ^1.1.0
     ts-node: ^10.7.0
     typescript: ~4.4.4
     workbox-build: ^6.6.0
@@ -6414,12 +6414,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ses@npm:^0.18.8":
-  version: 0.18.8
-  resolution: "ses@npm:0.18.8"
+"ses@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "ses@npm:1.1.0"
   dependencies:
-    "@endo/env-options": ^0.1.4
-  checksum: d7976d2ee218baec021c5cfdfb193d63b52bf2b6cbdbbb90c19d835915a1872b6924910f7fd42bc849eb2de78fc7bdd6e7b4667e1df3c79244cc92d4ede48aa6
+    "@endo/env-options": ^1.1.0
+  checksum: 20f69f610febba3c53144ae2cf5cb4c932212c17994fe84a2864634a24104675a4ee2498482b74f8a468e0e25d92fd104c8b45b1ab2c7029255221797db979be
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The `ses` package has been updated to the latest version. This update ensures that lockdown remains compatibile with later browser versions.

Fixes #144