### PR TITLE
remove globalthis polyfill

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -29,10 +29,6 @@ const filesFromPackages = [
     filename: 'design-tokens.css',
   },
   {
-    source: require.resolve('globalthis/dist/browser.js'),
-    filename: 'globalthis.js',
-  },
-  {
     source: minifiedLockdownSource,
     filename: 'lockdown-install.js',
   },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@metamask/object-multiplex": "^2.0.0",
     "@metamask/post-message-stream": "^8.0.0",
     "eth-phishing-detect": "^1.2.0",
-    "globalthis": "1.0.1",
     "punycode": "^2.3.1",
     "readable-stream": "^3.6.2",
     "ses": "^1.1.0"

--- a/static/index.html
+++ b/static/index.html
@@ -14,11 +14,6 @@
     </script>
     <title>MetaMask Phishing Detection</title>
     <script
-      src="./globalthis.js"
-      type="text/javascript"
-      charset="utf-8"
-    ></script>
-    <script
       src="./lockdown-install.js"
       type="text/javascript"
       charset="utf-8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1677,7 +1677,6 @@ __metadata:
     eth-phishing-detect: ^1.2.0
     exorcist: ^2.0.0
     fs-extra: ^11.1.1
-    globalthis: 1.0.1
     http-server: ^14.1.1
     minify-stream: ^2.1.0
     playwright: ~1.33.0
@@ -4257,15 +4256,6 @@ __metadata:
   dependencies:
     type-fest: ^0.20.2
   checksum: c55ea8fd3afecb72567bac41605577e19e68476993dfb0ca4c49b86075af5f0ae3f0f5502525f69010f7c5ea5db6a1c540a80a4f80ebdfb2f686d87b0f05d7e9
-  languageName: node
-  linkType: hard
-
-"globalthis@npm:1.0.1":
-  version: 1.0.1
-  resolution: "globalthis@npm:1.0.1"
-  dependencies:
-    define-properties: ^1.1.3
-  checksum: d80d625355ebd1174144290766ce96a1465966370d35a05897e3fb96e031493b2c117fb92b55a94dba2f33031e498b5776d03437965ed4514815e6122c78d18c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR removes the `globalThis.js` polyfill as all build targets of `metamask-extension` now support `globalThis` natively. The dependency was originally pinned in #1 to align with extension version.

The `.babelrc.json` file can likely similarly be revisited and updated to lessen the amount of transpiling further.

#### Related
- https://github.com/MetaMask/metamask-extension/pull/22529