### PR TITLE
fix: Update phishingSafelistStream to send origin as a parameter for safelistPhishingDomain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **BREAKING**: Update `phishingSafelistStream` steam to send `origin` instead of `hostname` as a parameter for `safelistPhishingDomain` method ([#165](https://github.com/MetaMask/phishing-warning/pull/165))
+
 ## [3.0.4]
 ### Changed
 - Update index.html - update attribution copy ([#161](https://github.com/MetaMask/phishing-warning/pull/161))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- **BREAKING**: Update `phishingSafelistStream` steam to send `origin` instead of `hostname` as a parameter for `safelistPhishingDomain` method ([#165](https://github.com/MetaMask/phishing-warning/pull/165))
+- **BREAKING**: Update `phishingSafelistStream` to send `origin` instead of `hostname` as a parameter for `safelistPhishingDomain` method ([#165](https://github.com/MetaMask/phishing-warning/pull/165))
 
 ## [3.0.4]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
 ### Changed
 - **BREAKING**: Update `phishingSafelistStream` to send `origin` instead of `hostname` as a parameter for `safelistPhishingDomain` method ([#165](https://github.com/MetaMask/phishing-warning/pull/165))
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,20 +145,20 @@ async function isBlockedByMetamask(href: string) {
  * @param href - The href value to check.
  */
 function getSuspect(href = ''): {
-  suspectHostname: string;
   suspectHostnameUnicode: string;
   suspectHref: string;
   suspectHrefUnicode: string;
+  suspectOrigin: string;
 } {
   try {
     const url = new URL(href);
     const unicodeHostname = toUnicode(url.hostname);
     const unicodeHref = `${url.protocol}//${unicodeHostname}${url.pathname}${url.search}${url.hash}`;
     return {
-      suspectHostname: url.hostname,
       suspectHostnameUnicode: unicodeHostname,
       suspectHref: url.href,
       suspectHrefUnicode: unicodeHref,
+      suspectOrigin: url.origin,
     };
   } catch (error) {
     throw new Error(`Invalid 'href' query parameter`);
@@ -200,10 +200,10 @@ function start() {
   const hashQueryString = new URLSearchParams(hashContents);
 
   const {
-    suspectHostname,
     suspectHref,
     suspectHostnameUnicode,
     suspectHrefUnicode,
+    suspectOrigin
   } = getSuspect(hashQueryString.get('href'));
 
   const suspectLink = document.getElementById('suspect-link');
@@ -242,7 +242,7 @@ function start() {
     phishingSafelistStream.write({
       jsonrpc: '2.0',
       method: 'safelistPhishingDomain',
-      params: [suspectHostname],
+      params: [suspectOrigin],
       id: createRandomId(),
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -203,7 +203,7 @@ function start() {
     suspectHref,
     suspectHostnameUnicode,
     suspectHrefUnicode,
-    suspectOrigin
+    suspectOrigin,
   } = getSuspect(hashQueryString.get('href'));
 
   const suspectLink = document.getElementById('suspect-link');

--- a/tests/bypass.spec.ts
+++ b/tests/bypass.spec.ts
@@ -6,7 +6,7 @@ test.beforeEach(async ({ context }) => {
   await setupDefaultMocks(context);
 });
 
-test('allows the user to bypass the warning and add the site to the allowlist', async ({
+test('allows the user to bypass the warning and add the site origin to the allowlist', async ({
   page,
 }) => {
   const postMessageLogs = await setupStreamInitialization(page);
@@ -24,7 +24,7 @@ test('allows the user to bypass the warning and add the site to the allowlist', 
       id: expect.any(Number),
       jsonrpc: '2.0',
       method: 'safelistPhishingDomain',
-      params: ['test.com'],
+      params: ['http://test.com'],
     },
     name: 'metamask-phishing-safelist',
   });

--- a/tests/bypass.spec.ts
+++ b/tests/bypass.spec.ts
@@ -24,7 +24,7 @@ test('allows the user to bypass the warning and add the site origin to the allow
       id: expect.any(Number),
       jsonrpc: '2.0',
       method: 'safelistPhishingDomain',
-      params: ['http://test.com'],
+      params: ['https://test.com'],
     },
     name: 'metamask-phishing-safelist',
   });


### PR DESCRIPTION
Update`phishingSafelistStream` to send`origin` instead of `hostname` as a parameter for `safelistPhishingDomain`.
