### PR TITLE
fix: Incomplete URL scheme check

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -86,7 +86,7 @@ function setupOpenSelfInNewTabLink() {
  */
 function isValidSuspectHref(href: string) {
   /* eslint-disable-next-line */
-  const disallowedProtocols = ['javascript:'];
+  const disallowedProtocols = ['javascript:', 'data:', 'vbscript:'];
   const parsedSuspectHref = new URL(href);
 
   return disallowedProtocols.indexOf(parsedSuspectHref.protocol) < 0;


### PR DESCRIPTION
To fix the problem, we need to extend the `disallowedProtocols` array to include `data:` and `vbscript:` schemes. This ensures that URLs with these schemes are also considered invalid, thereby enhancing the security of the URL validation logic.

- Modify the `disallowedProtocols` array to include `data:` and `vbscript:` schemes.
- Ensure that the `isValidSuspectHref` function correctly identifies these schemes as disallowed.


### Related
- Fixes [https://github.com/MetaMask/phishing-warning/security/code-scanning/1](https://github.com/MetaMask/phishing-warning/security/code-scanning/1)
- Follow-up to #16