### PR TITLE
fix: avoid creating playwright artifact with same name across node versions

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -105,9 +105,9 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report
+          name: playwright-report-node-${{ matrix.node-version }}
           path: playwright-report/
-          retention-days: 30
+          retention-days: 5
 
       - name: Require clean working directory
         shell: bash


### PR DESCRIPTION
## Summary

Right now CI is [failing](https://github.com/MetaMask/phishing-warning/actions/runs/14602831798/job/40964957426?pr=191) due to the fact that we attempt to upload multiple artifacts with the same name. This PR fixes that by ensuring that each artifact created (for each node version) has unique names.