### PR TITLE
fix: add overflow protection on very long urls

### DIFF
--- a/static/index.css
+++ b/static/index.css
@@ -149,6 +149,8 @@ button {
   display: flex;
   flex-direction: column;
   gap: 16px;
+  overflow: hidden;
+  max-width: 100%;
 }
 
 .warning-icon {


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/eth-phishing-detect/issues/160813

**BEFORE**
<img width="1832" height="1442" alt="image" src="https://github.com/user-attachments/assets/957f24d1-f4e8-4caa-950a-fe8e00772b82" />

**AFTER**
<img width="1832" height="1442" alt="image" src="https://github.com/user-attachments/assets/542c2585-a666-4c6e-a7bc-e3b22997d42d" />
