### PR TITLE
feat: sends href to `safelistPhishingDomain`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -182,7 +182,7 @@ function start() {
     phishingSafelistStream.write({
       jsonrpc: '2.0',
       method: 'safelistPhishingDomain',
-      params: [suspectOrigin],
+      params: [suspectHref],
       id: createRandomId(),
     });
 

--- a/tests/bypass.spec.ts
+++ b/tests/bypass.spec.ts
@@ -24,7 +24,56 @@ test('allows the user to bypass the warning and add the site origin to the allow
       id: expect.any(Number),
       jsonrpc: '2.0',
       method: 'safelistPhishingDomain',
-      params: ['https://test.com'],
+      params: ['https://test.com/'],
+    },
+    name: 'metamask-phishing-safelist',
+  });
+});
+
+test('allows the user to bypass the warning with URL path and sends full href', async ({
+  page,
+}) => {
+  const postMessageLogs = await setupStreamInitialization(page);
+  const testUrl = 'https://test-phishing-domain.invalid/path';
+  const hashParams = new URLSearchParams({
+    href: testUrl,
+  });
+
+  await page.goto(`/#${hashParams}`);
+  await page.locator('css=#unsafe-continue').click();
+
+  await expect(postMessageLogs.length).toBe(1);
+  await expect(postMessageLogs[0].message).toStrictEqual({
+    data: {
+      id: expect.any(Number),
+      jsonrpc: '2.0',
+      method: 'safelistPhishingDomain',
+      params: [testUrl],
+    },
+    name: 'metamask-phishing-safelist',
+  });
+});
+
+test('allows bypass with complex URL including query parameters and fragments', async ({
+  page,
+}) => {
+  const postMessageLogs = await setupStreamInitialization(page);
+  const complexUrl =
+    'https://test-complex.invalid/path?param=value&other=test#section';
+  const hashParams = new URLSearchParams({
+    href: complexUrl,
+  });
+
+  await page.goto(`/#${hashParams}`);
+  await page.locator('css=#unsafe-continue').click();
+
+  await expect(postMessageLogs.length).toBe(1);
+  await expect(postMessageLogs[0].message).toStrictEqual({
+    data: {
+      id: expect.any(Number),
+      jsonrpc: '2.0',
+      method: 'safelistPhishingDomain',
+      params: [complexUrl],
     },
     name: 'metamask-phishing-safelist',
   });


### PR DESCRIPTION
Send the `suspectHref` (i.e. the href that is sent from the extension) back via the `safelistPhishingDomain` stream so that we can correctly handle bypasses for paths correctly.