### PR TITLE
fix: `build:prod` step

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "scripts": {
     "build": "node ./build/index.js",
-    "build:prod": "NODE='production' yarn build",
+    "build:prod": "NODE_ENV='production' yarn build",
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:eslint": "eslint . --cache --ext js,ts",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",


### PR DESCRIPTION
`build/index.js` uses `NODE_ENV` not `NODE`. See here: https://github.com/MetaMask/phishing-warning/blob/2d6db12dea32068f3ec863085d5a785bfac163f9/build/index.js#L54C1-L55C1